### PR TITLE
Add noscript visit counting via image

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nuxt/types'
 
 export const chiffreEmbedScriptUrl = 'https://embed.chiffre.io/analytics.js'
 export const chiffrePushBaseUrl = 'https://push.chiffre.io/event'
+export const chiffrePushNoScriptUrl = 'https://push.chiffre.io/noscript'
 
 export interface Options {
   projectId?: string
@@ -40,6 +41,11 @@ const chiffreModule: Module<Options> = function (moduleOptions) {
     async: true,
     defer: true,
   }
+  const chiffreNoScriptImg = `<img
+  src="${chiffrePushNoScriptUrl}/${options.projectId}?xhr=noscript"
+  alt="Chiffre.io anonymous visit counting for clients without JavaScript"
+  crossorigin="anonymous"
+/>`
 
   const enabled =
     (!this.options.dev &&
@@ -50,6 +56,10 @@ const chiffreModule: Module<Options> = function (moduleOptions) {
 
   if (enabled && this.options.head && this.options.head.script) {
     this.options.head.script.push(chiffreConfig, chiffreScript)
+    this.options.head.noscript?.push({
+      body: true,
+      innerHTML: chiffreNoScriptImg,
+    })
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,6 +27,7 @@ const chiffreModule: Module<Options> = function (moduleOptions) {
   const chiffreConfig = {
     id: 'chiffre:analytics-config',
     type: 'application/json',
+    body: true,
     json: {
       ...(options.publicKey ? { publicKey: options.publicKey } : {}),
       ...(options.projectId
@@ -40,6 +41,7 @@ const chiffreModule: Module<Options> = function (moduleOptions) {
     crossOrigin: 'anonymous',
     async: true,
     defer: true,
+    body: true,
   }
   const chiffreNoScriptImg = `<img
   src="${chiffrePushNoScriptUrl}/${options.projectId}?xhr=noscript"

--- a/src/module.ts
+++ b/src/module.ts
@@ -58,10 +58,20 @@ const chiffreModule: Module<Options> = function (moduleOptions) {
 
   if (enabled && this.options.head && this.options.head.script) {
     this.options.head.script.push(chiffreConfig, chiffreScript)
-    this.options.head.noscript?.push({
-      body: true,
-      innerHTML: chiffreNoScriptImg,
-    })
+    this.options.head.noscript = [
+      ...(this.options.head.noscript || []),
+      {
+        body: true,
+        once: true,
+        hid: 'chiffre:noscript', // for Nuxt.js, see nuxt/vue-meta#537
+        vmid: 'chiffre:noscript', // for vue-meta
+        innerHTML: chiffreNoScriptImg,
+      },
+    ]
+    this.options.head.__dangerouslyDisableSanitizersByTagID = {
+      ...this.options.head.__dangerouslyDisableSanitizersByTagID,
+      'chiffre:noscript': ['innerHTML'],
+    }
   }
 }
 

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -47,12 +47,14 @@ function checkEnabled(moduleThis: ModuleThis, chiffreOptions: Options): void {
           publicKey: chiffreOptions.publicKey,
           pushURL: `${chiffrePushBaseUrl}/${chiffreOptions.projectId}`,
         },
+        body: true,
       },
       {
         async: true,
         crossOrigin: 'anonymous',
         defer: true,
         src: chiffreEmbedScriptUrl,
+        body: true,
       },
     ],
     noscript: [

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -60,6 +60,9 @@ function checkEnabled(moduleThis: ModuleThis, chiffreOptions: Options): void {
     noscript: [
       {
         body: true,
+        once: true,
+        hid: 'chiffre:noscript',
+        vmid: 'chiffre:noscript',
         innerHTML: `<img
   src="${chiffrePushNoScriptUrl}/${chiffreOptions.projectId}?xhr=noscript"
   alt="Chiffre.io anonymous visit counting for clients without JavaScript"
@@ -67,6 +70,9 @@ function checkEnabled(moduleThis: ModuleThis, chiffreOptions: Options): void {
 />`,
       },
     ],
+    __dangerouslyDisableSanitizersByTagID: {
+      'chiffre:noscript': ['innerHTML'],
+    },
   })
 }
 

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -3,6 +3,7 @@ import module, {
   defaultOptions,
   chiffreEmbedScriptUrl,
   chiffrePushBaseUrl,
+  chiffrePushNoScriptUrl,
 } from '../src/module'
 import { MetaInfo } from 'vue-meta'
 
@@ -24,6 +25,7 @@ function generateModuleThis(chiffreOptions?: Options): ModuleThis {
       dev: false,
       head: {
         script: [],
+        noscript: [],
       },
       ...(chiffreOptions ? { chiffre: chiffreOptions } : {}),
     },
@@ -32,7 +34,7 @@ function generateModuleThis(chiffreOptions?: Options): ModuleThis {
 }
 
 function checkDisabled(moduleThis: ModuleThis): void {
-  expect(moduleThis.options.head).toStrictEqual({ script: [] })
+  expect(moduleThis.options.head).toStrictEqual({ script: [], noscript: [] })
 }
 
 function checkEnabled(moduleThis: ModuleThis, chiffreOptions: Options): void {
@@ -51,6 +53,16 @@ function checkEnabled(moduleThis: ModuleThis, chiffreOptions: Options): void {
         crossOrigin: 'anonymous',
         defer: true,
         src: chiffreEmbedScriptUrl,
+      },
+    ],
+    noscript: [
+      {
+        body: true,
+        innerHTML: `<img
+  src="${chiffrePushNoScriptUrl}/${chiffreOptions.projectId}?xhr=noscript"
+  alt="Chiffre.io anonymous visit counting for clients without JavaScript"
+  crossorigin="anonymous"
+/>`,
       },
     ],
   })


### PR DESCRIPTION
I'm not sure how this would render on a Nuxt build, ideally it should add 

```html
<noscript>
  <img ... />
</noscript>
``` 
at the end of `<body>`, for tracking page views when JavaScript is disabled.

See [chiffre-io/push@`29dd24ce`](https://github.com/chiffre-io/push/commit/29dd24ceafd8bd98940ebf896a5876876393c363#diff-9b57d17c6e9bcb4a5f10d245971934c2R269-R303) for associated route implementation, which generates an empty event server-side. We assume DNT for clients with no JavaScript running.